### PR TITLE
Integrate zizmor into CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,3 +78,20 @@ jobs:
       - name: Run tests
         run: |
           go test -count=1 -cover ./...
+
+  zizmor:
+    name: Zizmor Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # for checkout
+      security-events: write # for uploading code scanning results
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+        with:
+          persona: pedantic


### PR DESCRIPTION
- Integrate zizmor into CI.
- Update default branch ruleset:
  - Add new zizmor job to required status checks.
  - Add zizmor to required code scanning results.

Fixes #11.