### PR TITLE
Run CI workflow on pushes to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,9 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Run CI when pushing to main to better track unexpected breakages.