### PR TITLE
Configure dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,8 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 4
+    commit-message:
+      prefix: "chore: "
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -27,6 +29,8 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 4
+    commit-message:
+      prefix: "chore: "
     groups:
       x-repos:
         patterns:


### PR DESCRIPTION
Configure dependabot to raise PRs with a "chore: " prefix to align with conventional commits. This isn't smart enough to detect breaking changes, but we can deal with those manually if needed.

Fixes #24.