### PR TITLE
chore: Bump dependabot cooldown days to resolve zizmor alerts

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,7 +16,7 @@ updates:
       time: "08:00"
       timezone: "Europe/London"
     cooldown:
-      default-days: 4
+      default-days: 7
     commit-message:
       prefix: "chore: "
 
@@ -28,7 +28,7 @@ updates:
       time: "08:00"
       timezone: "Europe/London"
     cooldown:
-      default-days: 4
+      default-days: 7
     commit-message:
       prefix: "chore: "
     groups:


### PR DESCRIPTION
- Fixes https://github.com/mattdowdell/mockerylint/security/code-scanning/6
- Fixes https://github.com/mattdowdell/mockerylint/security/code-scanning/7