### PR TITLE
ci: Validate PR titles follow conventional commits

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   pr:
-    name: Validate PR title
+    name: PR Title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read # for reading pr titles


### PR DESCRIPTION
Require PR titles to follow the conventional commits spec, e.g. prefixed with `chore:`, `ci:`, `docs:`, etc.

Fixes #1.