### PR TITLE
test: Assert diagnostic fields analysistest cannot see

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1,12 +1,35 @@
 package mockerylint_test
 
 import (
+	"go/ast"
+	"go/token"
+	"slices"
 	"testing"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 
 	"github.com/mattdowdell/mockerylint"
 )
+
+// rules are the categories a diagnostic may carry. They are spelled out rather than
+// taken from the analyzer so that a renamed constant fails the test instead of quietly
+// changing the output.
+var rules = map[string]bool{
+	"usefactory":  true,
+	"useexpecter": true,
+	"usetimes":    true,
+}
+
+// methods maps a diagnostic message to the methods it may point at. The messages about
+// initialising a mock are absent because they point at an expression rather than at a
+// method call.
+var methods = map[string][]string{
+	"use .EXPECT instead of .On":                                        {"On"},
+	".Test() can be removed when using mock factory":                    {"Test"},
+	".AssertExpectations() can be removed when using mock factory":      {"AssertExpectations"},
+	"expectation should call .Maybe(), .Once(), .Twice(), or .Times(N)": {"Return", "RunAndReturn"},
+}
 
 func TestAnalyzer(t *testing.T) {
 	tests := map[string]struct {
@@ -28,7 +51,99 @@ func TestAnalyzer(t *testing.T) {
 			analyzer := mockerylint.New()
 			testdata := analysistest.TestData()
 
-			analysistest.Run(t, testdata, analyzer, tt.dir)
+			results := analysistest.Run(t, testdata, analyzer, tt.dir)
+
+			checkResults(t, results)
 		})
 	}
+}
+
+// checkResults asserts the properties of a diagnostic that analysistest cannot see. Its
+// want comments are matched on the line and the message alone, leaving the category, the
+// position within the line, and the suppression of generated files unchecked.
+func checkResults(t *testing.T, results []*analysistest.Result) {
+	t.Helper()
+
+	var generated int
+
+	for _, result := range results {
+		pkg := result.Action.Package
+		suppressed := generatedFiles(pkg.Fset, pkg.Syntax)
+		generated += len(suppressed)
+
+		for _, diag := range result.Action.Diagnostics {
+			pos := pkg.Fset.Position(diag.Pos)
+
+			if !rules[diag.Category] {
+				t.Errorf("%s: %q has category %q, want a rule name", pos, diag.Message, diag.Category)
+			}
+
+			if suppressed[pos.Filename] {
+				t.Errorf("%s: %q reported against generated code", pos, diag.Message)
+			}
+
+			checkPosition(t, pos, pkg.Syntax, &diag)
+		}
+	}
+
+	// Suppression is only being exercised while there is something to suppress, and the
+	// check above would pass unnoticed if the generated files lost their header.
+	if generated == 0 {
+		t.Error("no generated files found, so nothing exercises suppressing them")
+	}
+}
+
+// checkPosition asserts that a diagnostic about a method call points at the method
+// rather than at the receiver its chain starts from.
+func checkPosition(t *testing.T, pos token.Position, files []*ast.File, diag *analysis.Diagnostic) {
+	t.Helper()
+
+	want, ok := methods[diag.Message]
+	if !ok {
+		return
+	}
+
+	got := identAt(files, diag.Pos)
+
+	if !slices.Contains(want, got) {
+		t.Errorf("%s: %q points at %q, want one of %q", pos, diag.Message, got, want)
+	}
+}
+
+// generatedFiles returns the names of the files carrying a generated code header, which
+// the analyzer is expected to skip.
+func generatedFiles(fset *token.FileSet, files []*ast.File) map[string]bool {
+	names := make(map[string]bool)
+
+	for _, file := range files {
+		if ast.IsGenerated(file) {
+			names[fset.Position(file.FileStart).Filename] = true
+		}
+	}
+
+	return names
+}
+
+// identAt returns the name of the identifier starting at pos, or an empty string when
+// the position does not start one.
+func identAt(files []*ast.File, pos token.Pos) string {
+	for _, file := range files {
+		if pos < file.FileStart || pos >= file.FileEnd {
+			continue
+		}
+
+		var name string
+
+		ast.Inspect(file, func(node ast.Node) bool {
+			if ident, ok := node.(*ast.Ident); ok && ident.Pos() == pos {
+				name = ident.Name
+			}
+
+			return name == ""
+		})
+
+		return name
+	}
+
+	return ""
 }


### PR DESCRIPTION
Description

analysistest matches a // want comment against the line and the message of a diagnostic and nothing else. checkMessage is called with an empty name and f.Message, so the category and the column take no part in matching. Everything else a diagnostic carries is unasserted.

That has left the last three changes to the analyzer unguarded:

┌───────────────────────────────────────────────────┬────────────┬────────────┐
│                     Property                      │ Changed in │ Guarded by │
├───────────────────────────────────────────────────┼────────────┼────────────┤
│ Diagnostic points at the method, not the receiver │ 6759f35    │ nothing    │
├───────────────────────────────────────────────────┼────────────┼────────────┤
│ Generated files produce no diagnostics            │ 0a97d5c    │ nothing    │
├───────────────────────────────────────────────────┼────────────┼────────────┤
│ Every diagnostic carries a rule category          │ 2f5e990    │ nothing    │
└───────────────────────────────────────────────────┴────────────┴────────────┘

Each was verified by hand at the time, by rendering a caret at the reported column, by diffing the output of the built binary, and by tabulating the JSON. None of that runs in CI, so all three are one careless refactor away from reverting in silence.

Generated file suppression is the worst of the three, because it is not merely unguarded. A regression that started reporting inside mocks_test.go would surface as diagnostics in a file with no // want comments, so the failure would name the generated file rather than the cause, and the obvious repair would be to add the missing comments.

This adds a check of the diagnostics that analysistest.Run returns, which closes all three at once.

Changes

- Fed the results of analysistest.Run into a new checkResults. Run already returns them and they were being discarded. Reusing them keeps the analyzer running once per package rather than twice.
- Asserted the category of every diagnostic is one of the three rule names. The names are literals in the test rather than the constants from analyzer.go, so renaming a constant is a failure rather than a silent change to the output.
- Asserted no diagnostic falls in a file that ast.IsGenerated accepts. The set of generated files is computed from the syntax of the package rather than hardcoded to mocks_test.go, so another generated file added to testdata is covered when it arrives.
- Asserted that at least one generated file was found. Without it the check above passes whenever the headers are lost, which is the case it exists to catch.
- Asserted that the four method call diagnostics point at an identifier naming the method the message is about. Asserting the identifier rather than a column number keeps the test stable when testdata is reordered. The three initialisation diagnostics point at an expression rather than a method and are excluded.
- Took *analysis.Diagnostic in checkPosition rather than a value, as gocritic flags the 112 byte struct. It is an accommodation for the linter, not a sign the function mutates anything.

No change to analyzer.go and no change to testdata.

Notes for reviewers

On whether the test does anything

A new test passing is weak evidence, so each property was mutated in analyzer.go and the test run against it. Every mutation was reverted afterwards and the branch holds no change to analyzer.go.

┌───────────────────────────────────────────┬─────────────────────────────────────────────────┐
│                 Mutation                  │                     Result                      │
├───────────────────────────────────────────┼─────────────────────────────────────────────────┤
│ Drop Category from report                 │ 38 category failures                            │
├───────────────────────────────────────────┼─────────────────────────────────────────────────┤
│ selector.Sel.Pos() becomes selector.Pos() │ 29 position failures                            │
├───────────────────────────────────────────┼─────────────────────────────────────────────────┤
│ ast.IsGenerated(file) becomes false       │ suppression failures in all three mocks_test.go │
└───────────────────────────────────────────┴─────────────────────────────────────────────────┘

29 is the expected count for the second one: 38 diagnostics less the 9 initialisation diagnostics that the position check skips.

The second mutation is the regression from 6759f35 reproduced exactly, and its output is the argument for the whole change:

usetimes_test.go:65:2: "expectation should call ..." points at "m", want one of ["Return" "RunAndReturn"]

Every // want comment still matched during that run. Same line, same message, wrong column.

The vacuity guard was checked by inverting it to generated > 0, which failed in all three subtests, so each package does contribute a generated file.

On what remains unasserted

End, SuggestedFixes and Related are all unset by the analyzer and are not asserted. The initialisation diagnostics have their line asserted by the // want comments and their column by nothing, as there is no method name to anchor an assertion to and the alternative is a literal column number that breaks whenever testdata moves.

Coverage is 91.1%. go build, go vet, golangci-lint run and golangci-lint fmt all pass.

## Description

Please provide a concise overview of the change and why it is useful.
If the change fixes any open issues, please list them here.

## Changes

Please list the details of all changes made.
When reasonable, focus on behaviour and API changes rather than implementation details.
